### PR TITLE
Reveal already revealed cells to reveal non-flagged neighbors 

### DIFF
--- a/src/structure/game_state.py
+++ b/src/structure/game_state.py
@@ -207,7 +207,7 @@ class GameState:
         # reveal it and all other hidden cells connected to it if they are not mined.
         elif cell.state is st.CellState.Hidden:
             self.__inner_reveal(cell)
-            return False 
+            return False
         
         # If the cell is visible and the number of flagged neighbors equals
         # the number of mined neighbors, reveal all non-flagged neighbors.


### PR DESCRIPTION
This small change adds the ability to reveal cells that are already revealed.
If the the number of neighbors with mines matches the number of flags placed in the neighbors, all non-flagged neighbors are revealed. This behavior can be found in many modern minesweeper versions.

This would relate to `Addative` maintenance.
This change was tested manually. I can add real tests after #56 has been merged.